### PR TITLE
Added support for jpeg files

### DIFF
--- a/src/pathtraverser.cpp
+++ b/src/pathtraverser.cpp
@@ -22,7 +22,7 @@ RecursivePathTraverser::~RecursivePathTraverser() {}
 
 QStringList RecursivePathTraverser::getImages() const
 {
-    QDirIterator it(QString(path.c_str()), QStringList() << "*.jpg" << "*.JPG", QDir::Files, QDirIterator::Subdirectories);
+    QDirIterator it(QString(path.c_str()), QStringList() << "*.jpg" << "*.JPG" << "*.jpeg" << "*.JPEG", QDir::Files, QDirIterator::Subdirectories);
     QStringList files;
     while (it.hasNext())
     {
@@ -46,7 +46,7 @@ DefaultPathTraverser::~DefaultPathTraverser() {}
 
 QStringList DefaultPathTraverser::getImages() const
 {
-  return directory.entryList(QStringList() << "*.jpg" << "*.JPG", QDir::Files);
+  return directory.entryList(QStringList() << "*.jpg" << "*.JPG" << "*.jpeg" << "*.JPEG", QDir::Files);
 }
 
 const std::string DefaultPathTraverser::getImagePath(const std::string image) const


### PR DESCRIPTION
Added .jpeg and .JPEG in the file whitelist to support .jpeg files as well. 
.jpg is just a shortcut for .jpeg files because old OSes did only support 3-character fileformats. 