### PR TITLE
Fixed full screen behaviour

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -25,6 +25,7 @@ MainWindow::MainWindow(QWidget *parent) :
     QLabel *label = this->findChild<QLabel*>("image");
     setCentralWidget(label);
     label->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
+    showFullScreen();
     update();
 
 }


### PR DESCRIPTION
In case the screen resulution did not match the size set in
mainwindow.ui, you may only see part of the image shown. Putting the
window in full screen explicitly fixes that issue.