### PR TITLE
Fixing issues with displays smaller than the window size

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -25,6 +25,7 @@ MainWindow::MainWindow(QWidget *parent) :
     QLabel *label = this->findChild<QLabel*>("image");
     setCentralWidget(label);
     label->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
+    showFullScreen();
     update();
 
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -25,7 +25,6 @@ MainWindow::MainWindow(QWidget *parent) :
     QLabel *label = this->findChild<QLabel*>("image");
     setCentralWidget(label);
     label->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
-    showFullScreen();
     update();
 
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -20,6 +20,8 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->setupUi(this);
     setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
 
+    setAttribute(Qt::WA_AcceptTouchEvents);
+
     QTimer::singleShot(5, this, SLOT(showFullScreen()));
     QApplication::setOverrideCursor(Qt::BlankCursor);
     QLabel *label = this->findChild<QLabel*>("image");
@@ -42,6 +44,59 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
     }
     else
         QWidget::keyPressEvent(event);
+}
+
+bool isTouchEvent(const QEvent &event)
+{
+    if(event.type() == QEvent::TouchBegin)
+        return true;
+    if(event.type() == QEvent::TouchUpdate)
+        return true;
+    return false;    
+}
+
+bool isQuitCombination(const QTouchEvent &touchEvent)
+{
+    bool topLeftTouched = false;
+    bool topRightTouched = false;
+    bool bottomLeftTouched = false;
+    bool bottomRightTouched = false;
+    for(const auto &touchPoint : touchEvent.touchPoints())
+    {
+        const qreal normalizedCornerSize = 0.1;
+        const qreal x = touchPoint.normalizedPos().x();
+        const qreal y = touchPoint.normalizedPos().y();
+        if(x < normalizedCornerSize)
+        {
+            if(y < normalizedCornerSize)
+                topLeftTouched = true;
+            else if(y > 1-normalizedCornerSize)
+                bottomLeftTouched = true;
+        }
+        else if(x > 1-normalizedCornerSize)
+        {
+            if(y < normalizedCornerSize)
+                topRightTouched = true;
+            else if(y > 1-normalizedCornerSize)
+                bottomRightTouched = true;
+        }
+    }
+    return topLeftTouched && topRightTouched
+        && bottomLeftTouched && bottomRightTouched;
+}
+
+bool MainWindow::event(QEvent* event)
+{
+    if(isTouchEvent(*event))
+    {
+        if(isQuitCombination(dynamic_cast<QTouchEvent&>(*event)))
+            QCoreApplication::quit();
+    }
+    else
+    {
+        return QMainWindow::event(event);
+    }
+    return true;
 }
 
 void MainWindow::resizeEvent(QResizeEvent* event)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -16,8 +16,9 @@ class MainWindow : public QMainWindow
 
 public:
     explicit MainWindow(QWidget *parent = 0);
-    void keyPressEvent(QKeyEvent* event);
-    void resizeEvent(QResizeEvent* event);
+    void keyPressEvent(QKeyEvent* event) override;
+    bool event(QEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
     ~MainWindow();
     void setImage(std::string path);
     void setBlurRadius(unsigned int blurRadius);

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1500</width>
-    <height>945</height>
+    <width>1</width>
+    <height>1</height>
    </rect>
   </property>
   <property name="sizePolicy">


### PR DESCRIPTION
If the window defined in src/mainwindow.ui exceeds the size of the display, the program behaves weirdly. Growing the window size even further leads to crashes. Reducing the window size to 1x1px seems to work fine and should be smaller than any display size.