### PR TITLE
Reduce window size for small display support

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1500</width>
-    <height>945</height>
+    <width>1</width>
+    <height>1</height>
    </rect>
   </property>
   <property name="sizePolicy">


### PR DESCRIPTION
Pictures will show wrong resize behavior at the beginning of a slide show, when the window size exceeds the display size. As the Window will be shown in full screen anyway, an initial window size of 1x1px should support all display sizes.