### PR TITLE
Folder options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ This project is maintained by myself during my spare time. If you like and use i
 ## Usage
 
 ```
-slide [-t rotation_seconds] [-a aspect] [-o background_opacity(0..255)] [-b blur_radius] -p image_folder [-r] [-O overlay_string] [-v] [--verbose] [--stretch]
+slide [-t rotation_seconds] [-a aspect] [-o background_opacity(0..255)] [-b blur_radius] [-p image_folder|-i imageFile,...] [-r] [-O overlay_string] [-v] [--verbose] [--stretch]
 ```
 
 * `image_folder`: where to search for images (.jpg files)
+* `-i imageFile,...`: comma delimited list of full paths to image files to display
 * `-r` for recursive traversal of `image_folder`
 * `-s` for shuffle instead of random image rotation
 * `-S` for sorted rotation (files ordered by name, first images then subfolders)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,16 @@ slide [-t rotation_seconds] [-a aspect] [-o background_opacity(0..255)] [-b blur
     * `<dir>`directory of the current image
     * `<path>`path to the current image without filename
   * Example: `slide -p ./images -O "20|60|Time: <time>;;;Picture taken at <exifdatetime>"`
-      
+
+## Folder Options file
+When using the default or recursive folder mode we support having per folder display options. The options are stored in a file called "options.json" and currently support the following option
+```
+{
+    "fitAspectAxisToWindow": false
+}
+```
+* `fitAspectAxisToWindow` : apply the --stretch option to files in this folder
+
 ## Dependencies
 
 * qt5-qmake

--- a/src/imageselector.h
+++ b/src/imageselector.h
@@ -8,28 +8,36 @@
 class MainWindow;
 class PathTraverser;
 
+struct ImageOptions_t
+{
+    char aspect;
+    bool fitAspectAxisToWindow;
+    int rotation;
+};
+
 class ImageSelector
 {
 public:
-    ImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspectIn);
+    ImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspectIn, bool fitAspectAxisToWindow);
     virtual ~ImageSelector();
-    virtual std::string getNextImage() = 0;
+    virtual const std::string getNextImage(ImageOptions_t &options) = 0;
     void setDebugMode(bool debugModeIn) { debugMode = debugModeIn;}
 
 protected:
     int getImageRotation(const std::string &fileName);
-    bool imageValidForAspect(const std::string &fileName);
+    bool imageValidForAspect(const std::string &fileName, const int rotation);
     std::unique_ptr<PathTraverser>& pathTraverser;
     char aspect;
+    bool fitAspectAxisToWindow = false;
     bool debugMode = false;
 };
 
 class RandomImageSelector : public ImageSelector
 {
 public:
-    RandomImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspect);
+    RandomImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspect, bool fitAspectAxisToWindow);
     virtual ~RandomImageSelector();
-    virtual std::string getNextImage();
+    virtual const std::string getNextImage(ImageOptions_t &options);
 
 private:
     unsigned int selectRandom(const QStringList& images) const;
@@ -38,9 +46,9 @@ private:
 class ShuffleImageSelector : public ImageSelector
 {
 public:
-    ShuffleImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspect);
+    ShuffleImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspect, bool fitAspectAxisToWindow);
     virtual ~ShuffleImageSelector();
-    virtual std::string getNextImage();
+    virtual const std::string getNextImage(ImageOptions_t &options);
 
 private:
     int current_image_shuffle;
@@ -50,9 +58,9 @@ private:
 class SortedImageSelector : public ImageSelector
 {
 public:
-    SortedImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspect);
+    SortedImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspect, bool fitAspectAxisToWindow);
     virtual ~SortedImageSelector();
-    virtual std::string getNextImage();
+    virtual const std::string getNextImage(ImageOptions_t &options);
 
 private:
     QStringList images;

--- a/src/imageswitcher.cpp
+++ b/src/imageswitcher.cpp
@@ -21,7 +21,8 @@ ImageSwitcher::ImageSwitcher(MainWindow& w, unsigned int timeout, std::unique_pt
 
 void ImageSwitcher::updateImage()
 {
-    std::string filename(selector->getNextImage());
+    ImageOptions_t options;
+    std::string filename(selector->getNextImage(options));
     if (filename == "")
     {
       window.warn("No image found.");
@@ -29,7 +30,7 @@ void ImageSwitcher::updateImage()
     }
     else
     {
-      window.setImage(filename);
+      window.setImage(filename, options);
       timerNoContent.stop(); // we have loaded content so stop the fast polling
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,29 +116,29 @@ int main(int argc, char *argv[])
   std::unique_ptr<PathTraverser> pathTraverser;
   if (!imageList.empty())
   {
-    pathTraverser = std::unique_ptr<PathTraverser>(new ImageListPathTraverser(imageList));
+    pathTraverser = std::unique_ptr<PathTraverser>(new ImageListPathTraverser(imageList, debugMode));
   }
   else if (recursive)
   {
-    pathTraverser = std::unique_ptr<PathTraverser>(new RecursivePathTraverser(path));
+    pathTraverser = std::unique_ptr<PathTraverser>(new RecursivePathTraverser(path, debugMode));
   }
   else
   {
-    pathTraverser = std::unique_ptr<PathTraverser>(new DefaultPathTraverser(path));
+    pathTraverser = std::unique_ptr<PathTraverser>(new DefaultPathTraverser(path, debugMode));
   }
 
   std::unique_ptr<ImageSelector> selector;
   if (sorted)
   {
-    selector = std::unique_ptr<ImageSelector>(new SortedImageSelector(pathTraverser, aspect));
+    selector = std::unique_ptr<ImageSelector>(new SortedImageSelector(pathTraverser, aspect, fitAspectAxisToWindow));
   }
   else if (shuffle)
   {
-    selector = std::unique_ptr<ImageSelector>(new ShuffleImageSelector(pathTraverser, aspect));
+    selector = std::unique_ptr<ImageSelector>(new ShuffleImageSelector(pathTraverser, aspect, fitAspectAxisToWindow));
   }
   else
   {
-    selector = std::unique_ptr<ImageSelector>(new RandomImageSelector(pathTraverser, aspect));
+    selector = std::unique_ptr<ImageSelector>(new RandomImageSelector(pathTraverser, aspect, fitAspectAxisToWindow));
   }
   selector->setDebugMode(debugMode);
   if(debugMode)
@@ -149,9 +149,7 @@ int main(int argc, char *argv[])
   Overlay o(overlay);
   o.setDebugMode(debugMode);
   w.setOverlay(&o);
-  w.setAspect(aspect);
   w.setDebugMode(debugMode);
-  w.setFitAspectAxisToWindow(fitAspectAxisToWindow);
   w.show();
 
   ImageSwitcher switcher(w, rotationSeconds * 1000, selector);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,7 @@ int main(int argc, char *argv[])
   bool fitAspectAxisToWindow = false;
   std::string valid_aspects = "alp"; // all, landscape, portait
   std::string overlay = "";
+  std::string imageList = ""; // comma delimited list of images to show
   int debugInt = 0;
   int stretchInt = 0;
   static struct option long_options[] =
@@ -43,7 +44,7 @@ int main(int argc, char *argv[])
     {"stretch", no_argument,       &stretchInt, 1},
   };
   int option_index = 0;
-  while ((opt = getopt_long(argc, argv, "b:p:t:o:O:a:rsSv", long_options, &option_index)) != -1) {
+  while ((opt = getopt_long(argc, argv, "b:p:t:o:O:a:i:rsSv", long_options, &option_index)) != -1) {
     switch (opt) {
       case 0:
           /* If this option set a flag, do nothing else now. */
@@ -88,6 +89,9 @@ int main(int argc, char *argv[])
       case 'v':
         debugMode = true;
         break;
+      case 'i':
+        imageList = optarg;
+        break;
       default: /* '?' */
         usage(argv[0]);
         return 1;
@@ -102,7 +106,7 @@ int main(int argc, char *argv[])
     fitAspectAxisToWindow = true;
   }
 
-  if (path.empty())
+  if (path.empty() && imageList.empty())
   {
     std::cout << "Error: Path expected." << std::endl;
     usage(argv[0]);
@@ -110,7 +114,11 @@ int main(int argc, char *argv[])
   }
 
   std::unique_ptr<PathTraverser> pathTraverser;
-  if (recursive)
+  if (!imageList.empty())
+  {
+    pathTraverser = std::unique_ptr<PathTraverser>(new ImageListPathTraverser(imageList));
+  }
+  else if (recursive)
   {
     pathTraverser = std::unique_ptr<PathTraverser>(new RecursivePathTraverser(path));
   }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -152,7 +152,7 @@ void MainWindow::setOverlay(Overlay* o)
 
 QPixmap MainWindow::getBlurredBackground(const QPixmap& originalSize, const QPixmap& scaled)
 {
-    if (fitAspectAxisToWindow) {
+    if (imageOptions.fitAspectAxisToWindow) {
       // our scaled version will just fill the whole screen, us it directly
       return scaled.copy();
     } else if (scaled.width() < width()) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -53,45 +53,11 @@ void MainWindow::resizeEvent(QResizeEvent* event)
    updateImage(true);
 }
 
-void MainWindow::setImage(std::string path)
+void MainWindow::setImage(const std::string& path, const ImageOptions_t& options)
 {
     currentImage = path;
+    imageOptions = options;
     updateImage(false);
-}
-
-int MainWindow::getImageRotation()
-{
-    if (currentImage == "")
-        return 0;
-
-    int orientation = 0;
-    ExifData *exifData = exif_data_new_from_file(currentImage.c_str());
-    if (exifData)
-    {
-      ExifByteOrder byteOrder = exif_data_get_byte_order(exifData);
-      ExifEntry *exifEntry = exif_data_get_entry(exifData, EXIF_TAG_ORIENTATION);
-
-      if (exifEntry)
-      {
-        orientation = exif_get_short(exifEntry->data, byteOrder);
-      }
-      exif_data_free(exifData);
-    }
-
-    int degrees = 0;
-    switch(orientation) {
-        case 8:
-        degrees = 270;
-        break;
-        case 3:
-        degrees = 180;
-        break;
-        case 6:
-        degrees = 90;
-        break;
-    }
-
-    return degrees;
 }
 
 void MainWindow::updateImage(bool immediately)
@@ -184,11 +150,6 @@ void MainWindow::setOverlay(Overlay* o)
   overlay = o;
 }
 
-void MainWindow::setAspect(char aspectIn)
-{
-  aspect = aspectIn;
-}
-
 QPixmap MainWindow::getBlurredBackground(const QPixmap& originalSize, const QPixmap& scaled)
 {
     if (scaled.width() < width()) {
@@ -206,21 +167,21 @@ QPixmap MainWindow::getBlurredBackground(const QPixmap& originalSize, const QPix
 QPixmap MainWindow::getRotatedPixmap(const QPixmap& p)
 {
     QMatrix matrix;
-    matrix.rotate(getImageRotation());
+    matrix.rotate(imageOptions.rotation);
     return p.transformed(matrix);
 }
 
 QPixmap MainWindow::getScaledPixmap(const QPixmap& p)
 {
-  if (fitAspectAxisToWindow)
+  if (imageOptions.fitAspectAxisToWindow)
   {
-    if ( aspect == 'p')
+    if (imageOptions.aspect == 'p')
     {
       // potrait mode, make height of image fit screen and crop top/bottom
       QPixmap pTemp = p.scaledToHeight(height(), Qt::SmoothTransformation);
       return pTemp.copy(0,0,width(),height());
     }
-    else if ( aspect == 'l')
+    else if (imageOptions.aspect == 'l')
     {
       // landscape mode, make width of image fit screen and crop top/bottom
       QPixmap pTemp = p.scaledToWidth(width(), Qt::SmoothTransformation);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -3,6 +3,7 @@
 
 #include <QMainWindow>
 #include <QPixmap>
+#include "imageselector.h"
 
 namespace Ui {
 class MainWindow;
@@ -20,23 +21,20 @@ public:
     void keyPressEvent(QKeyEvent* event);
     void resizeEvent(QResizeEvent* event);
     ~MainWindow();
-    void setImage(std::string path);
+    void setImage(const std::string& path, const ImageOptions_t &options);
     void setBlurRadius(unsigned int blurRadius);
     void setBackgroundOpacity(unsigned int opacity);
     void warn(std::string text);
     void setOverlay(Overlay* overlay);
-    void setAspect(char aspectIn);
     void setDebugMode(bool debugModeIn) {debugMode = debugModeIn;}
-    void setFitAspectAxisToWindow(bool fitAspectAxisToWindowIn) { fitAspectAxisToWindow = fitAspectAxisToWindowIn; }
 private:
     Ui::MainWindow *ui;
 
     std::string currentImage;
     unsigned int blurRadius = 20;
     unsigned int backgroundOpacity = 150;
-    char aspect = 'a';
+    ImageOptions_t imageOptions;
     bool debugMode = false;
-    bool fitAspectAxisToWindow = false;
 
     Overlay* overlay;
 

--- a/src/pathtraverser.cpp
+++ b/src/pathtraverser.cpp
@@ -61,3 +61,24 @@ const std::string DefaultPathTraverser::getImagePath(const std::string image) co
 {
   return directory.filePath(QString(image.c_str())).toStdString();
 }
+
+
+ImageListPathTraverser::ImageListPathTraverser(const std::string &imageListString):
+  PathTraverser("")
+{
+  QString str = QString(imageListString.c_str());
+  imageList = str.split(QLatin1Char(','));
+}
+
+ImageListPathTraverser::~ImageListPathTraverser() {}
+
+
+QStringList ImageListPathTraverser::getImages() const
+{
+  return imageList;
+}
+
+const std::string ImageListPathTraverser::getImagePath(const std::string image) const
+{
+  return image;
+}

--- a/src/pathtraverser.h
+++ b/src/pathtraverser.h
@@ -41,4 +41,14 @@ class DefaultPathTraverser : public PathTraverser
     QDir directory;
 };
 
+class ImageListPathTraverser : public PathTraverser
+{
+  public:
+    ImageListPathTraverser(const std::string &imageListString);
+    virtual ~ImageListPathTraverser();
+    QStringList getImages() const;
+    virtual const std::string getImagePath(const std::string image) const;
+  private:
+    QStringList imageList;
+};
 #endif // PATHTRAVERSER_H

--- a/src/pathtraverser.h
+++ b/src/pathtraverser.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <QDir>
 #include <QStringList>
+#include "imageselector.h"
 
 static const QStringList supportedFormats={"jpg","jpeg","png","tif","tiff"};
 
@@ -11,32 +12,37 @@ class MainWindow;
 class PathTraverser
 {
   public:
-    PathTraverser(const std::string path);
+    PathTraverser(const std::string path, bool debugModeIn);
     virtual ~PathTraverser();
     virtual QStringList getImages() const = 0;
     virtual const std::string getImagePath(const std::string image) const = 0;
+    virtual void UpdateOptionsForImage(const std::string& filename, ImageOptions_t& options) const = 0;
 
   protected:
     const std::string path;
+    bool debugMode = false;
     QStringList getImageFormats() const;
+    void LoadOptionsForDirectory(const std::string &directoryPath, ImageOptions_t &options) const;
 };
 
 class RecursivePathTraverser : public PathTraverser
 {
   public:
-    RecursivePathTraverser(const std::string path);
+    RecursivePathTraverser(const std::string path, bool debugModeIn);
     virtual ~RecursivePathTraverser();
     QStringList getImages() const;
     virtual const std::string getImagePath(const std::string image) const;
+    virtual void UpdateOptionsForImage(const std::string& filename, ImageOptions_t& options) const;
 };
 
 class DefaultPathTraverser : public PathTraverser
 {
   public:
-    DefaultPathTraverser(const std::string path);
+    DefaultPathTraverser(const std::string path, bool debugModeIn);
     virtual ~DefaultPathTraverser();
     QStringList getImages() const;
     virtual const std::string getImagePath(const std::string image) const;
+    virtual void UpdateOptionsForImage(const std::string& filename, ImageOptions_t& options) const;
   private:
     QDir directory;
 };
@@ -44,10 +50,11 @@ class DefaultPathTraverser : public PathTraverser
 class ImageListPathTraverser : public PathTraverser
 {
   public:
-    ImageListPathTraverser(const std::string &imageListString);
+    ImageListPathTraverser(const std::string &imageListString, bool debugModeIn);
     virtual ~ImageListPathTraverser();
     QStringList getImages() const;
     virtual const std::string getImagePath(const std::string image) const;
+    virtual void UpdateOptionsForImage(const std::string& filename, ImageOptions_t& options) const;
   private:
     QStringList imageList;
 };


### PR DESCRIPTION
- Add support for different image display options per folder. Right now only image stretching is supported but more will be added. The image options are stored in an "options.json" and read when the image is displayed.
- Added "-i <image1>,<image2>" command line option to display a fixed list of images. Used for debugging  by me but could be useful elsewhere.
- 
