### PR TITLE
Folder options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ This project is maintained by myself during my spare time. If you like and use i
 ## Usage
 
 ```
-slide [-t rotation_seconds] [-a aspect] [-o background_opacity(0..255)] [-b blur_radius] -p image_folder [-r] [-O overlay_string] [-v] [--verbose] [--stretch]
+slide [-t rotation_seconds] [-a aspect] [-o background_opacity(0..255)] [-b blur_radius] [-p image_folder|-i imageFile,...] [-r] [-O overlay_string] [-v] [--verbose] [--stretch]
 ```
 
 * `image_folder`: where to search for images (.jpg files)
+* `-i imageFile,...`: comma delimited list of full paths to image files to display
 * `-r` for recursive traversal of `image_folder`
 * `-s` for shuffle instead of random image rotation
 * `-S` for sorted rotation (files ordered by name, first images then subfolders)

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ slide [-t rotation_seconds] [-a aspect] [-o background_opacity(0..255)] [-b blur
 * `-s` for shuffle instead of random image rotation
 * `-S` for sorted rotation (files ordered by name, first images then subfolders)
 * `rotation_seconds(default=30)`: time until next random image is chosen from the given folder
-* `aspect(default=a)`: the required aspect ratio of the picture to display. Valid values are 'a' (all), 'l' (landscape) and 'p' (portrait)
+* `aspect(default=a)`: the required aspect ratio of the picture to display. Valid values are 'a' (all), 'l' (landscape), 'p' (portrait) and 'm' (monitor). Monitor will match the aspect ratio of the display we are running on.
 * `background_opacity(default=150)`: opacity of the background filling image between 0 (black background) and 255
 * `blur_radius(default=20)`: blur radius of the background filling image
 * `-v` or `--verbose`: Verbose debug output when running, plus a thumbnail of the original image in the bottom left of the screen
-* `--stretch`: When in aspect mode 'l' or 'p' crop the image rather than leaving a blurred background. For example, in landscape mode this will make images as wide as the screen and crop the top and bottom to fit.
+* `--stretch`: When in aspect mode 'l','p' or 'm' crop the image rather than leaving a blurred background. For example, in landscape mode this will make images as wide as the screen and crop the top and bottom to fit.
 * `-O` is used to create a overlay string.
   * It defines overlays for all four edges in the order `top-left;top-right;bottom-left;bottom-right`
   * All edges overlays are separated by `;`

--- a/README.md
+++ b/README.md
@@ -46,7 +46,16 @@ slide [-t rotation_seconds] [-a aspect] [-o background_opacity(0..255)] [-b blur
     * `<dir>`directory of the current image
     * `<path>`path to the current image without filename
   * Example: `slide -p ./images -O "20|60|Time: <time>;;;Picture taken at <exifdatetime>"`
-      
+
+## Folder Options file
+When using the default or recursive folder mode we support having per folder display options. The options are stored in a file called "options.json" and currently support the following option
+```
+{
+    "fitAspectAxisToWindow": false
+}
+```
+* `fitAspectAxisToWindow` : apply the --stretch option to files in this folder
+
 ## Dependencies
 
 * qt5-qmake

--- a/src/imageselector.cpp
+++ b/src/imageselector.cpp
@@ -34,12 +34,10 @@ int ReadExifTag(ExifData* exifData, ExifTag tag, bool shortRead = false)
   {
     if (shortRead)
     {
-      value = exif_get_short(exifEntry->data, byteOrder);
+      return exif_get_short(exifEntry->data, byteOrder);
     }
-    else
-    {
-      value = exif_get_long(exifEntry->data, byteOrder);
-    }
+    
+    return exif_get_long(exifEntry->data, byteOrder);
   }
   return value;
 }

--- a/src/imageselector.cpp
+++ b/src/imageselector.cpp
@@ -50,7 +50,7 @@ int ImageSelector::getImageRotation(const std::string& fileName)
   return degrees;
 }
 
-bool ImageSelector::imageMatchesFilter(const std::string& fileName, int rotation)
+bool ImageSelector::imageMatchesFilter(const std::string& fileName, const int rotation)
 {
   if(!QFileInfo::exists(QString(fileName.c_str())))
   {
@@ -200,8 +200,8 @@ void ShuffleImageSelector::reloadImagesIfNoneLeft()
   }
 }
 
-SortedImageSelector::SortedImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspect):
-  ImageSelector(pathTraverser, aspect),
+SortedImageSelector::SortedImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspect, bool fitAspectAxisToWindow):
+  ImageSelector(pathTraverser, aspect, fitAspectAxisToWindow),
   images()
 {
   srand (time(NULL));

--- a/src/imageselector.cpp
+++ b/src/imageselector.cpp
@@ -159,8 +159,20 @@ std::string ShuffleImageSelector::getNextImage()
   std::string filename = pathTraverser->getImagePath(images.at(current_image_shuffle).toStdString());
   if(!QFileInfo::exists(QString(filename.c_str())))
   {
-    std::cout << "file not found: " << filename << std::endl;
-    current_image_shuffle = images.size();
+    if(debugMode)
+    {
+      std::cout << "file not found: " << filename << std::endl;
+    }
+    current_image_shuffle = current_image_shuffle + 1; // ignore and move to next image
+    return getNextImage();
+  }
+  if (!imageValidForAspect(filename))
+  {
+    if(debugMode)
+    {
+      std::cout << "image has invalid aspect: " << filename << "(images left:" << (images.size()-current_image_shuffle) << ")" << std::endl;
+    }
+    current_image_shuffle = current_image_shuffle + 1; // ignore and move to next image
     return getNextImage();
   }
   std::cout << "updating image: " << filename << std::endl;
@@ -197,10 +209,13 @@ std::string SortedImageSelector::getNextImage()
   {
     images = pathTraverser->getImages();
     std::sort(images.begin(), images.end());
-    std::cout << "read " << images.size() << " images." << std::endl;
-    for (int i = 0;i <images.size();i++){
-      
-        std::cout << images[i].toStdString() << std::endl;
+    if(debugMode)
+    {
+      std::cout << "read " << images.size() << " images." << std::endl;
+      for (int i = 0;i <images.size();i++){
+        
+          std::cout << images[i].toStdString() << std::endl;
+      }
     }
   }
   if (images.size() == 0)
@@ -210,9 +225,21 @@ std::string SortedImageSelector::getNextImage()
   std::string filename = pathTraverser->getImagePath(images.takeFirst().toStdString());
   if(!QFileInfo::exists(QString(filename.c_str())))
   {
-    std::cout << "file not found: " << filename << std::endl;
+    if(debugMode)
+    {
+      std::cout << "file not found: " << filename << std::endl;
+    }
     return getNextImage();
   }
+  if (!imageValidForAspect(filename))
+  {
+    if(debugMode)
+    {
+      std::cout << "image has invalid aspect: " << filename << std::endl;
+    }
+    return getNextImage();
+  }
+
   std::cout << "updating image: " << filename << std::endl;
   return filename;
 }

--- a/src/imageselector.h
+++ b/src/imageselector.h
@@ -8,28 +8,36 @@
 class MainWindow;
 class PathTraverser;
 
+struct ImageOptions_t
+{
+    char aspect;
+    bool fitAspectAxisToWindow;
+    int rotation;
+};
+
 class ImageSelector
 {
 public:
-    ImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspectIn);
+    ImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspectIn, bool fitAspectAxisToWindow);
     virtual ~ImageSelector();
-    virtual std::string getNextImage() = 0;
+    virtual const std::string getNextImage(ImageOptions_t &options) = 0;
     void setDebugMode(bool debugModeIn) { debugMode = debugModeIn;}
 
 protected:
     int getImageRotation(const std::string &fileName);
-    bool imageValidForAspect(const std::string &fileName);
+    bool imageValidForAspect(const std::string &fileName, const int rotation);
     std::unique_ptr<PathTraverser>& pathTraverser;
     char aspect;
+    bool fitAspectAxisToWindow = false;
     bool debugMode = false;
 };
 
 class RandomImageSelector : public ImageSelector
 {
 public:
-    RandomImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspect);
+    RandomImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspect, bool fitAspectAxisToWindow);
     virtual ~RandomImageSelector();
-    virtual std::string getNextImage();
+    virtual const std::string getNextImage(ImageOptions_t &options);
 
 private:
     unsigned int selectRandom(const QStringList& images) const;
@@ -38,9 +46,9 @@ private:
 class ShuffleImageSelector : public ImageSelector
 {
 public:
-    ShuffleImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspect);
+    ShuffleImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspect, bool fitAspectAxisToWindow);
     virtual ~ShuffleImageSelector();
-    virtual std::string getNextImage();
+    virtual const std::string getNextImage(ImageOptions_t &options);
 
 private:
     int current_image_shuffle;
@@ -50,9 +58,9 @@ private:
 class SortedImageSelector : public ImageSelector
 {
 public:
-    SortedImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspect);
+    SortedImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspect, bool fitAspectAxisToWindow);
     virtual ~SortedImageSelector();
-    virtual std::string getNextImage();
+    virtual const std::string getNextImage(ImageOptions_t &options);
 
 private:
     QStringList images;

--- a/src/imageselector.h
+++ b/src/imageselector.h
@@ -26,7 +26,7 @@ public:
 protected:
     int getImageRotation(const std::string &fileName);
     bool imageValidForAspect(const std::string &fileName, const int rotation);
-    bool imageMatchesFilter(const std::string& fileName);
+    bool imageMatchesFilter(const std::string& fileName, const int rotation);
     std::unique_ptr<PathTraverser>& pathTraverser;
     char aspect;
     bool fitAspectAxisToWindow = false;

--- a/src/imageselector.h
+++ b/src/imageselector.h
@@ -4,41 +4,33 @@
 #include <iostream>
 #include <memory>
 #include <QStringList>
+#include "imagestructs.h"
 
 class MainWindow;
 class PathTraverser;
 
-struct ImageOptions_t
-{
-    char aspect;
-    bool fitAspectAxisToWindow;
-    int rotation;
-};
-
 class ImageSelector
 {
 public:
-    ImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspectIn, bool fitAspectAxisToWindow);
+    ImageSelector(std::unique_ptr<PathTraverser>& pathTraverser);
     virtual ~ImageSelector();
-    virtual const std::string getNextImage(ImageOptions_t &options) = 0;
+    virtual const ImageDetails_t getNextImage(const ImageDisplayOptions_t &baseOptions) = 0;
     void setDebugMode(bool debugModeIn) { debugMode = debugModeIn;}
 
 protected:
-    int getImageRotation(const std::string &fileName);
-    bool imageValidForAspect(const std::string &fileName, const int rotation);
-    bool imageMatchesFilter(const std::string& fileName, const int rotation);
+    void populateImageDetails(const std::string&filename, ImageDetails_t &imageDetails, const ImageDisplayOptions_t &baseOptions);
+    bool imageValidForAspect(const ImageDetails_t& imageDetails);
+    bool imageMatchesFilter(const ImageDetails_t& imageDetails);
     std::unique_ptr<PathTraverser>& pathTraverser;
-    char aspect;
-    bool fitAspectAxisToWindow = false;
     bool debugMode = false;
 };
 
 class RandomImageSelector : public ImageSelector
 {
 public:
-    RandomImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspect, bool fitAspectAxisToWindow);
+    RandomImageSelector(std::unique_ptr<PathTraverser>& pathTraverser);
     virtual ~RandomImageSelector();
-    virtual const std::string getNextImage(ImageOptions_t &options);
+    virtual const ImageDetails_t getNextImage(const ImageDisplayOptions_t &baseOptions);
 
 private:
     unsigned int selectRandom(const QStringList& images) const;
@@ -47,9 +39,9 @@ private:
 class ShuffleImageSelector : public ImageSelector
 {
 public:
-    ShuffleImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspect, bool fitAspectAxisToWindow);
+    ShuffleImageSelector(std::unique_ptr<PathTraverser>& pathTraverser);
     virtual ~ShuffleImageSelector();
-    virtual const std::string getNextImage(ImageOptions_t &options);
+    virtual const ImageDetails_t getNextImage(const ImageDisplayOptions_t &baseOptions);
 
 private:
     void reloadImagesIfNoneLeft();
@@ -60,9 +52,9 @@ private:
 class SortedImageSelector : public ImageSelector
 {
 public:
-    SortedImageSelector(std::unique_ptr<PathTraverser>& pathTraverser, char aspect, bool fitAspectAxisToWindow);
+    SortedImageSelector(std::unique_ptr<PathTraverser>& pathTraverser);
     virtual ~SortedImageSelector();
-    virtual const std::string getNextImage(ImageOptions_t &options);
+    virtual const ImageDetails_t getNextImage(const ImageDisplayOptions_t &baseOptions);
 
 private:
     void reloadImagesIfEmpty();

--- a/src/imageselector.h
+++ b/src/imageselector.h
@@ -14,13 +14,13 @@ class ImageSelector
 public:
     ImageSelector(std::unique_ptr<PathTraverser>& pathTraverser);
     virtual ~ImageSelector();
-    virtual const ImageDetails_t getNextImage(const ImageDisplayOptions_t &baseOptions) = 0;
-    void setDebugMode(bool debugModeIn) { debugMode = debugModeIn;}
+    virtual const ImageDetails getNextImage(const ImageDisplayOptions &baseOptions) = 0;
+    void setDebugMode(bool debugModeIn);
 
 protected:
-    void populateImageDetails(const std::string&filename, ImageDetails_t &imageDetails, const ImageDisplayOptions_t &baseOptions);
-    bool imageValidForAspect(const ImageDetails_t& imageDetails);
-    bool imageMatchesFilter(const ImageDetails_t& imageDetails);
+    ImageDetails populateImageDetails(const std::string&filename, const ImageDisplayOptions &baseOptions);
+    bool imageValidForAspect(const ImageDetails& imageDetails);
+    bool imageMatchesFilter(const ImageDetails& imageDetails);
     std::unique_ptr<PathTraverser>& pathTraverser;
     bool debugMode = false;
 };
@@ -30,7 +30,7 @@ class RandomImageSelector : public ImageSelector
 public:
     RandomImageSelector(std::unique_ptr<PathTraverser>& pathTraverser);
     virtual ~RandomImageSelector();
-    virtual const ImageDetails_t getNextImage(const ImageDisplayOptions_t &baseOptions);
+    virtual const ImageDetails getNextImage(const ImageDisplayOptions &baseOptions);
 
 private:
     unsigned int selectRandom(const QStringList& images) const;
@@ -41,7 +41,7 @@ class ShuffleImageSelector : public ImageSelector
 public:
     ShuffleImageSelector(std::unique_ptr<PathTraverser>& pathTraverser);
     virtual ~ShuffleImageSelector();
-    virtual const ImageDetails_t getNextImage(const ImageDisplayOptions_t &baseOptions);
+    virtual const ImageDetails getNextImage(const ImageDisplayOptions &baseOptions);
 
 private:
     void reloadImagesIfNoneLeft();
@@ -54,7 +54,7 @@ class SortedImageSelector : public ImageSelector
 public:
     SortedImageSelector(std::unique_ptr<PathTraverser>& pathTraverser);
     virtual ~SortedImageSelector();
-    virtual const ImageDetails_t getNextImage(const ImageDisplayOptions_t &baseOptions);
+    virtual const ImageDetails getNextImage(const ImageDisplayOptions &baseOptions);
 
 private:
     void reloadImagesIfEmpty();

--- a/src/imagestructs.h
+++ b/src/imagestructs.h
@@ -4,24 +4,24 @@
 #include <string>
 
 // possible aspect ratios of an image
-enum EImageAspect { EImageAspect_Landscape = 0, EImageAspect_Portrait, EImageAspect_Any, EImageAspect_Monitor /* match monitors aspect */ };
+enum ImageAspect { ImageAspect_Landscape = 0, ImageAspect_Portrait, ImageAspect_Any, ImageAspect_Monitor /* match monitors aspect */ };
 
 // options to consider when displaying an image
-struct ImageDisplayOptions_t
+struct ImageDisplayOptions
 {
-    EImageAspect onlyAspect = EImageAspect_Any;
+    ImageAspect onlyAspect = ImageAspect_Any;
     bool fitAspectAxisToWindow = false;
 };
 
 // details of a particular image
-struct ImageDetails_t
+struct ImageDetails
 {
     int width = 0;
     int height = 0;
     int rotation = 0;
-    EImageAspect aspect = EImageAspect_Any;
+    ImageAspect aspect = ImageAspect_Any;
     std::string filename;
-    ImageDisplayOptions_t options;
+    ImageDisplayOptions options;
 };
 
 

--- a/src/imagestructs.h
+++ b/src/imagestructs.h
@@ -1,0 +1,28 @@
+#ifndef IMAGESTRUCTS_H
+#define IMAGESTRUCTS_H
+
+#include <string>
+
+// possible aspect ratios of an image
+enum EImageAspect { EImageAspect_Landscape = 0, EImageAspect_Portrait, EImageAspect_Any };
+
+// options to consider when displaying an image
+struct ImageDisplayOptions_t
+{
+    EImageAspect onlyAspect = EImageAspect_Any;
+    bool fitAspectAxisToWindow = false;
+};
+
+// details of a particular image
+struct ImageDetails_t
+{
+    int width = 0;
+    int height = 0;
+    int rotation = 0;
+    EImageAspect aspect = EImageAspect_Any;
+    std::string filename;
+    ImageDisplayOptions_t options;
+};
+
+
+#endif // IMAGESTRUCTS_H

--- a/src/imagestructs.h
+++ b/src/imagestructs.h
@@ -4,7 +4,7 @@
 #include <string>
 
 // possible aspect ratios of an image
-enum EImageAspect { EImageAspect_Landscape = 0, EImageAspect_Portrait, EImageAspect_Any };
+enum EImageAspect { EImageAspect_Landscape = 0, EImageAspect_Portrait, EImageAspect_Any, EImageAspect_Monitor /* match monitors aspect */ };
 
 // options to consider when displaying an image
 struct ImageDisplayOptions_t

--- a/src/imageswitcher.cpp
+++ b/src/imageswitcher.cpp
@@ -41,3 +41,9 @@ void ImageSwitcher::start()
     connect(&timerNoContent, SIGNAL(timeout()), this, SLOT(updateImage()));
     timer.start(timeout);
 }
+
+void ImageSwitcher::scheduleImageUpdate()
+{
+  // update our image in 100msec, to let the system settle
+  QTimer::singleShot(100, this, SLOT(updateImage())); 
+}

--- a/src/imageswitcher.cpp
+++ b/src/imageswitcher.cpp
@@ -21,16 +21,15 @@ ImageSwitcher::ImageSwitcher(MainWindow& w, unsigned int timeout, std::unique_pt
 
 void ImageSwitcher::updateImage()
 {
-    ImageOptions_t options;
-    std::string filename(selector->getNextImage(options));
-    if (filename == "")
+    ImageDetails_t imageDetails = selector->getNextImage(window.getBaseOptions());
+    if (imageDetails.filename == "")
     {
       window.warn("No image found.");
       timerNoContent.start(timeoutNoContent);
     }
     else
     {
-      window.setImage(filename, options);
+      window.setImage(imageDetails);
       timerNoContent.stop(); // we have loaded content so stop the fast polling
     }
 }

--- a/src/imageswitcher.cpp
+++ b/src/imageswitcher.cpp
@@ -21,7 +21,8 @@ ImageSwitcher::ImageSwitcher(MainWindow& w, unsigned int timeout, std::unique_pt
 
 void ImageSwitcher::updateImage()
 {
-    std::string filename(selector->getNextImage());
+    ImageOptions_t options;
+    std::string filename(selector->getNextImage(options));
     if (filename == "")
     {
       window.warn("No image found.");
@@ -29,7 +30,7 @@ void ImageSwitcher::updateImage()
     }
     else
     {
-      window.setImage(filename);
+      window.setImage(filename, options);
       timerNoContent.stop(); // we have loaded content so stop the fast polling
     }
 }

--- a/src/imageswitcher.cpp
+++ b/src/imageswitcher.cpp
@@ -21,7 +21,7 @@ ImageSwitcher::ImageSwitcher(MainWindow& w, unsigned int timeout, std::unique_pt
 
 void ImageSwitcher::updateImage()
 {
-    ImageDetails_t imageDetails = selector->getNextImage(window.getBaseOptions());
+    ImageDetails imageDetails = selector->getNextImage(window.getBaseOptions());
     if (imageDetails.filename == "")
     {
       window.warn("No image found.");

--- a/src/imageswitcher.h
+++ b/src/imageswitcher.h
@@ -14,6 +14,7 @@ class ImageSwitcher : public QObject
 public:
     ImageSwitcher(MainWindow& w, unsigned int timeout, std::unique_ptr<ImageSelector>& selector);
     void start();
+    void scheduleImageUpdate();
 
 public slots:
     void updateImage();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,29 +116,29 @@ int main(int argc, char *argv[])
   std::unique_ptr<PathTraverser> pathTraverser;
   if (!imageList.empty())
   {
-    pathTraverser = std::unique_ptr<PathTraverser>(new ImageListPathTraverser(imageList));
+    pathTraverser = std::unique_ptr<PathTraverser>(new ImageListPathTraverser(imageList, debugMode));
   }
   else if (recursive)
   {
-    pathTraverser = std::unique_ptr<PathTraverser>(new RecursivePathTraverser(path));
+    pathTraverser = std::unique_ptr<PathTraverser>(new RecursivePathTraverser(path, debugMode));
   }
   else
   {
-    pathTraverser = std::unique_ptr<PathTraverser>(new DefaultPathTraverser(path));
+    pathTraverser = std::unique_ptr<PathTraverser>(new DefaultPathTraverser(path, debugMode));
   }
 
   std::unique_ptr<ImageSelector> selector;
   if (sorted)
   {
-    selector = std::unique_ptr<ImageSelector>(new SortedImageSelector(pathTraverser, aspect));
+    selector = std::unique_ptr<ImageSelector>(new SortedImageSelector(pathTraverser, aspect, fitAspectAxisToWindow));
   }
   else if (shuffle)
   {
-    selector = std::unique_ptr<ImageSelector>(new ShuffleImageSelector(pathTraverser, aspect));
+    selector = std::unique_ptr<ImageSelector>(new ShuffleImageSelector(pathTraverser, aspect, fitAspectAxisToWindow));
   }
   else
   {
-    selector = std::unique_ptr<ImageSelector>(new RandomImageSelector(pathTraverser, aspect));
+    selector = std::unique_ptr<ImageSelector>(new RandomImageSelector(pathTraverser, aspect, fitAspectAxisToWindow));
   }
   selector->setDebugMode(debugMode);
   if(debugMode)
@@ -149,9 +149,7 @@ int main(int argc, char *argv[])
   Overlay o(overlay);
   o.setDebugMode(debugMode);
   w.setOverlay(&o);
-  w.setAspect(aspect);
   w.setDebugMode(debugMode);
-  w.setFitAspectAxisToWindow(fitAspectAxisToWindow);
   w.show();
 
   ImageSwitcher switcher(w, rotationSeconds * 1000, selector);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,7 @@ int main(int argc, char *argv[])
   bool fitAspectAxisToWindow = false;
   std::string valid_aspects = "alp"; // all, landscape, portait
   std::string overlay = "";
+  std::string imageList = ""; // comma delimited list of images to show
   int debugInt = 0;
   int stretchInt = 0;
   static struct option long_options[] =
@@ -43,7 +44,7 @@ int main(int argc, char *argv[])
     {"stretch", no_argument,       &stretchInt, 1},
   };
   int option_index = 0;
-  while ((opt = getopt_long(argc, argv, "b:p:t:o:O:a:rsSv", long_options, &option_index)) != -1) {
+  while ((opt = getopt_long(argc, argv, "b:p:t:o:O:a:i:rsSv", long_options, &option_index)) != -1) {
     switch (opt) {
       case 0:
           /* If this option set a flag, do nothing else now. */
@@ -88,6 +89,9 @@ int main(int argc, char *argv[])
       case 'v':
         debugMode = true;
         break;
+      case 'i':
+        imageList = optarg;
+        break;
       default: /* '?' */
         usage(argv[0]);
         return 1;
@@ -102,7 +106,7 @@ int main(int argc, char *argv[])
     fitAspectAxisToWindow = true;
   }
 
-  if (path.empty())
+  if (path.empty() && imageList.empty())
   {
     std::cout << "Error: Path expected." << std::endl;
     usage(argv[0]);
@@ -110,7 +114,11 @@ int main(int argc, char *argv[])
   }
 
   std::unique_ptr<PathTraverser> pathTraverser;
-  if (recursive)
+  if (!imageList.empty())
+  {
+    pathTraverser = std::unique_ptr<PathTraverser>(new ImageListPathTraverser(imageList));
+  }
+  else if (recursive)
   {
     pathTraverser = std::unique_ptr<PathTraverser>(new RecursivePathTraverser(path));
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ int main(int argc, char *argv[])
   bool shuffle = false;
   bool sorted = false;
   bool debugMode = false;
-  ImageDisplayOptions_t baseDisplayOptions;
+  ImageDisplayOptions baseDisplayOptions;
   std::string valid_aspects = "alpm"; // all, landscape, portait
   std::string overlay = "";
   std::string imageList = ""; // comma delimited list of images to show
@@ -59,24 +59,24 @@ int main(int argc, char *argv[])
         if ( valid_aspects.find(optarg[0]) == std::string::npos )
         {
           std::cout << "Invalid Aspect option, defaulting to all" << std::endl;
-          baseDisplayOptions.onlyAspect = EImageAspect_Any;
+          baseDisplayOptions.onlyAspect = ImageAspect_Any;
         }
         else
         {
           switch(optarg[0])
           {
             case 'l':
-              baseDisplayOptions.onlyAspect = EImageAspect_Landscape;
+              baseDisplayOptions.onlyAspect = ImageAspect_Landscape;
               break;
             case 'p':
-              baseDisplayOptions.onlyAspect = EImageAspect_Portrait;
+              baseDisplayOptions.onlyAspect = ImageAspect_Portrait;
               break;
             case 'm':
-              baseDisplayOptions.onlyAspect = EImageAspect_Monitor;
+              baseDisplayOptions.onlyAspect = ImageAspect_Monitor;
               break;
             default:
             case 'a':
-              baseDisplayOptions.onlyAspect = EImageAspect_Any;
+              baseDisplayOptions.onlyAspect = ImageAspect_Any;
               break;
           }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,8 +31,7 @@ int main(int argc, char *argv[])
   bool shuffle = false;
   bool sorted = false;
   bool debugMode = false;
-  char aspect = 'a';
-  bool fitAspectAxisToWindow = false;
+  ImageDisplayOptions_t baseDisplayOptions;
   std::string valid_aspects = "alp"; // all, landscape, portait
   std::string overlay = "";
   std::string imageList = ""; // comma delimited list of images to show
@@ -57,11 +56,26 @@ int main(int argc, char *argv[])
         path = optarg;
         break;
       case 'a':
-        aspect = optarg[0];
-        if ( valid_aspects.find(aspect) == std::string::npos )
+        if ( valid_aspects.find(optarg[0]) == std::string::npos )
         {
           std::cout << "Invalid Aspect option, defaulting to all" << std::endl;
-          aspect = 'a';
+          baseDisplayOptions.onlyAspect = EImageAspect_Any;
+        }
+        else
+        {
+          switch(optarg[0])
+          {
+            case 'l':
+              baseDisplayOptions.onlyAspect = EImageAspect_Landscape;
+              break;
+            case 'p':
+              baseDisplayOptions.onlyAspect = EImageAspect_Portrait;
+              break;
+            default:
+            case 'a':
+              baseDisplayOptions.onlyAspect = EImageAspect_Any;
+              break;
+          }
         }
         break;
       case 't':
@@ -103,7 +117,7 @@ int main(int argc, char *argv[])
   }
   if(stretchInt==1)
   {
-    fitAspectAxisToWindow = true;
+    baseDisplayOptions.fitAspectAxisToWindow = true;
   }
 
   if (path.empty() && imageList.empty())
@@ -130,15 +144,15 @@ int main(int argc, char *argv[])
   std::unique_ptr<ImageSelector> selector;
   if (sorted)
   {
-    selector = std::unique_ptr<ImageSelector>(new SortedImageSelector(pathTraverser, aspect, fitAspectAxisToWindow));
+    selector = std::unique_ptr<ImageSelector>(new SortedImageSelector(pathTraverser));
   }
   else if (shuffle)
   {
-    selector = std::unique_ptr<ImageSelector>(new ShuffleImageSelector(pathTraverser, aspect, fitAspectAxisToWindow));
+    selector = std::unique_ptr<ImageSelector>(new ShuffleImageSelector(pathTraverser));
   }
   else
   {
-    selector = std::unique_ptr<ImageSelector>(new RandomImageSelector(pathTraverser, aspect, fitAspectAxisToWindow));
+    selector = std::unique_ptr<ImageSelector>(new RandomImageSelector(pathTraverser));
   }
   selector->setDebugMode(debugMode);
   if(debugMode)
@@ -150,6 +164,7 @@ int main(int argc, char *argv[])
   o.setDebugMode(debugMode);
   w.setOverlay(&o);
   w.setDebugMode(debugMode);
+  w.setBaseOptions(baseDisplayOptions);
   w.show();
 
   ImageSwitcher switcher(w, rotationSeconds * 1000, selector);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,7 @@ int main(int argc, char *argv[])
   bool sorted = false;
   bool debugMode = false;
   ImageDisplayOptions_t baseDisplayOptions;
-  std::string valid_aspects = "alp"; // all, landscape, portait
+  std::string valid_aspects = "alpm"; // all, landscape, portait
   std::string overlay = "";
   std::string imageList = ""; // comma delimited list of images to show
   int debugInt = 0;
@@ -70,6 +70,9 @@ int main(int argc, char *argv[])
               break;
             case 'p':
               baseDisplayOptions.onlyAspect = EImageAspect_Portrait;
+              break;
+            case 'm':
+              baseDisplayOptions.onlyAspect = EImageAspect_Monitor;
               break;
             default:
             case 'a':
@@ -168,6 +171,7 @@ int main(int argc, char *argv[])
   w.show();
 
   ImageSwitcher switcher(w, rotationSeconds * 1000, selector);
+  w.setImageSwitcher(&switcher);
   switcher.start();
   return a.exec();
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -108,16 +108,15 @@ void MainWindow::resizeEvent(QResizeEvent* event)
    updateImage(true);
 }
 
-void MainWindow::setImage(const std::string& path, const ImageOptions_t& options)
+void MainWindow::setImage(const ImageDetails_t &imageDetails)
 {
-    currentImage = path;
-    imageOptions = options;
+    currentImage = imageDetails;
     updateImage(false);
 }
 
 void MainWindow::updateImage(bool immediately)
 {
-    if (currentImage == "")
+    if (currentImage.filename == "")
       return;
 
     QLabel *label = this->findChild<QLabel*>("image");
@@ -129,7 +128,7 @@ void MainWindow::updateImage(bool immediately)
       this->setPalette(palette);
     }
 
-    QPixmap p( currentImage.c_str() );
+    QPixmap p( currentImage.filename.c_str() );
     if(debugMode)
     {
       std::cout << "size:" << p.width() << "x" << p.height() << std::endl;
@@ -142,10 +141,10 @@ void MainWindow::updateImage(bool immediately)
     
     if (overlay != NULL)
     {
-      drawText(background, overlay->getMarginTopLeft(), overlay->getFontsizeTopLeft(), overlay->getRenderedTopLeft(currentImage).c_str(), Qt::AlignTop|Qt::AlignLeft);
-      drawText(background, overlay->getMarginTopRight(), overlay->getFontsizeTopRight(), overlay->getRenderedTopRight(currentImage).c_str(), Qt::AlignTop|Qt::AlignRight);
-      drawText(background, overlay->getMarginBottomLeft(), overlay->getFontsizeBottomLeft(), overlay->getRenderedBottomLeft(currentImage).c_str(), Qt::AlignBottom|Qt::AlignLeft);
-      drawText(background, overlay->getMarginBottomRight(), overlay->getFontsizeBottomRight(), overlay->getRenderedBottomRight(currentImage).c_str(), Qt::AlignBottom|Qt::AlignRight);
+      drawText(background, overlay->getMarginTopLeft(), overlay->getFontsizeTopLeft(), overlay->getRenderedTopLeft(currentImage.filename).c_str(), Qt::AlignTop|Qt::AlignLeft);
+      drawText(background, overlay->getMarginTopRight(), overlay->getFontsizeTopRight(), overlay->getRenderedTopRight(currentImage.filename).c_str(), Qt::AlignTop|Qt::AlignRight);
+      drawText(background, overlay->getMarginBottomLeft(), overlay->getFontsizeBottomLeft(), overlay->getRenderedBottomLeft(currentImage.filename).c_str(), Qt::AlignBottom|Qt::AlignLeft);
+      drawText(background, overlay->getMarginBottomRight(), overlay->getFontsizeBottomRight(), overlay->getRenderedBottomRight(currentImage.filename).c_str(), Qt::AlignBottom|Qt::AlignRight);
       if (debugMode)
       {
         // draw a thumbnail version of the source image in the bottom left, to check for cropping issues
@@ -207,7 +206,7 @@ void MainWindow::setOverlay(Overlay* o)
 
 QPixmap MainWindow::getBlurredBackground(const QPixmap& originalSize, const QPixmap& scaled)
 {
-    if (imageOptions.fitAspectAxisToWindow) {
+    if (currentImage.options.fitAspectAxisToWindow) {
       // our scaled version will just fill the whole screen, us it directly
       return scaled.copy();
     } else if (scaled.width() < width()) {
@@ -225,21 +224,21 @@ QPixmap MainWindow::getBlurredBackground(const QPixmap& originalSize, const QPix
 QPixmap MainWindow::getRotatedPixmap(const QPixmap& p)
 {
     QMatrix matrix;
-    matrix.rotate(imageOptions.rotation);
+    matrix.rotate(currentImage.rotation);
     return p.transformed(matrix);
 }
 
 QPixmap MainWindow::getScaledPixmap(const QPixmap& p)
 {
-  if (imageOptions.fitAspectAxisToWindow)
+  if (currentImage.options.fitAspectAxisToWindow)
   {
-    if (imageOptions.aspect == 'p')
+    if (currentImage.aspect == EImageAspect_Portrait)
     {
       // potrait mode, make height of image fit screen and crop top/bottom
       QPixmap pTemp = p.scaledToHeight(height(), Qt::SmoothTransformation);
       return pTemp.copy(0,0,width(),height());
     }
-    else if (imageOptions.aspect == 'l')
+    else if (currentImage.aspect == EImageAspect_Landscape)
     {
       // landscape mode, make width of image fit screen and crop top/bottom
       QPixmap pTemp = p.scaledToWidth(width(), Qt::SmoothTransformation);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -152,7 +152,7 @@ void MainWindow::setOverlay(Overlay* o)
 
 QPixmap MainWindow::getBlurredBackground(const QPixmap& originalSize, const QPixmap& scaled)
 {
-    if (fitAspectAxisToWindow) {
+    if (imageOptions.fitAspectAxisToWindow) {
       // our scaled version will just fill the whole screen, us it directly
       return scaled.copy();
     } else if (scaled.width() < width()) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -113,7 +113,7 @@ void MainWindow::resizeEvent(QResizeEvent* event)
   bool isLandscape = screenSize.width() > screenSize.height();
   if (imageAspectMatchesMonitor)
   {
-    baseImageOptions.onlyAspect = isLandscape ? EImageAspect_Landscape : EImageAspect_Portrait; 
+    baseImageOptions.onlyAspect = isLandscape ? ImageAspect_Landscape : ImageAspect_Portrait; 
   }
   if(debugMode)
   {
@@ -143,7 +143,7 @@ void MainWindow::checkWindowSize()
 }
 
 
-void MainWindow::setImage(const ImageDetails_t &imageDetails)
+void MainWindow::setImage(const ImageDetails &imageDetails)
 {
     currentImage = imageDetails;
     updateImage(false);
@@ -268,13 +268,13 @@ QPixmap MainWindow::getScaledPixmap(const QPixmap& p)
 {
   if (currentImage.options.fitAspectAxisToWindow)
   {
-    if (currentImage.aspect == EImageAspect_Portrait)
+    if (currentImage.aspect == ImageAspect_Portrait)
     {
       // potrait mode, make height of image fit screen and crop top/bottom
       QPixmap pTemp = p.scaledToHeight(height(), Qt::SmoothTransformation);
       return pTemp.copy(0,0,width(),height());
     }
-    else if (currentImage.aspect == EImageAspect_Landscape)
+    else if (currentImage.aspect == ImageAspect_Landscape)
     {
       // landscape mode, make width of image fit screen and crop top/bottom
       QPixmap pTemp = p.scaledToWidth(width(), Qt::SmoothTransformation);
@@ -339,12 +339,27 @@ void MainWindow::warn(std::string text)
   label->setText(text.c_str());
 }
 
-void MainWindow::setBaseOptions(const ImageDisplayOptions_t &baseOptionsIn) 
+void MainWindow::setBaseOptions(const ImageDisplayOptions &baseOptionsIn) 
 { 
   baseImageOptions = baseOptionsIn; 
-  if(baseImageOptions.onlyAspect == EImageAspect_Monitor)
+  if(baseImageOptions.onlyAspect == ImageAspect_Monitor)
   {
     imageAspectMatchesMonitor = true;
-    baseImageOptions.onlyAspect = width() >= height() ? EImageAspect_Landscape : EImageAspect_Portrait;
+    baseImageOptions.onlyAspect = width() >= height() ? ImageAspect_Landscape : ImageAspect_Portrait;
   }
+}
+
+void MainWindow::setImageSwitcher(ImageSwitcher *switcherIn)
+{
+   switcher = switcherIn; 
+}
+
+void MainWindow::setDebugMode(bool debugModeIn) 
+{
+  debugMode = debugModeIn;
+}
+
+const ImageDisplayOptions &MainWindow::getBaseOptions() 
+{
+   return baseImageOptions; 
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -53,45 +53,11 @@ void MainWindow::resizeEvent(QResizeEvent* event)
    updateImage(true);
 }
 
-void MainWindow::setImage(std::string path)
+void MainWindow::setImage(const std::string& path, const ImageOptions_t& options)
 {
     currentImage = path;
+    imageOptions = options;
     updateImage(false);
-}
-
-int MainWindow::getImageRotation()
-{
-    if (currentImage == "")
-        return 0;
-
-    int orientation = 0;
-    ExifData *exifData = exif_data_new_from_file(currentImage.c_str());
-    if (exifData)
-    {
-      ExifByteOrder byteOrder = exif_data_get_byte_order(exifData);
-      ExifEntry *exifEntry = exif_data_get_entry(exifData, EXIF_TAG_ORIENTATION);
-
-      if (exifEntry)
-      {
-        orientation = exif_get_short(exifEntry->data, byteOrder);
-      }
-      exif_data_free(exifData);
-    }
-
-    int degrees = 0;
-    switch(orientation) {
-        case 8:
-        degrees = 270;
-        break;
-        case 3:
-        degrees = 180;
-        break;
-        case 6:
-        degrees = 90;
-        break;
-    }
-
-    return degrees;
 }
 
 void MainWindow::updateImage(bool immediately)
@@ -184,11 +150,6 @@ void MainWindow::setOverlay(Overlay* o)
   overlay = o;
 }
 
-void MainWindow::setAspect(char aspectIn)
-{
-  aspect = aspectIn;
-}
-
 QPixmap MainWindow::getBlurredBackground(const QPixmap& originalSize, const QPixmap& scaled)
 {
     if (scaled.width() < width()) {
@@ -206,21 +167,21 @@ QPixmap MainWindow::getBlurredBackground(const QPixmap& originalSize, const QPix
 QPixmap MainWindow::getRotatedPixmap(const QPixmap& p)
 {
     QMatrix matrix;
-    matrix.rotate(getImageRotation());
+    matrix.rotate(imageOptions.rotation);
     return p.transformed(matrix);
 }
 
 QPixmap MainWindow::getScaledPixmap(const QPixmap& p)
 {
-  if (fitAspectAxisToWindow)
+  if (imageOptions.fitAspectAxisToWindow)
   {
-    if ( aspect == 'p')
+    if (imageOptions.aspect == 'p')
     {
       // potrait mode, make height of image fit screen and crop top/bottom
       QPixmap pTemp = p.scaledToHeight(height(), Qt::SmoothTransformation);
       return pTemp.copy(0,0,width(),height());
     }
-    else if ( aspect == 'l')
+    else if (imageOptions.aspect == 'l')
     {
       // landscape mode, make width of image fit screen and crop top/bottom
       QPixmap pTemp = p.scaledToWidth(width(), Qt::SmoothTransformation);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -3,6 +3,7 @@
 
 #include <QMainWindow>
 #include <QPixmap>
+#include "imageselector.h"
 
 namespace Ui {
 class MainWindow;
@@ -20,23 +21,20 @@ public:
     void keyPressEvent(QKeyEvent* event);
     void resizeEvent(QResizeEvent* event);
     ~MainWindow();
-    void setImage(std::string path);
+    void setImage(const std::string& path, const ImageOptions_t &options);
     void setBlurRadius(unsigned int blurRadius);
     void setBackgroundOpacity(unsigned int opacity);
     void warn(std::string text);
     void setOverlay(Overlay* overlay);
-    void setAspect(char aspectIn);
     void setDebugMode(bool debugModeIn) {debugMode = debugModeIn;}
-    void setFitAspectAxisToWindow(bool fitAspectAxisToWindowIn) { fitAspectAxisToWindow = fitAspectAxisToWindowIn; }
 private:
     Ui::MainWindow *ui;
 
     std::string currentImage;
     unsigned int blurRadius = 20;
     unsigned int backgroundOpacity = 150;
-    char aspect = 'a';
+    ImageOptions_t imageOptions;
     bool debugMode = false;
-    bool fitAspectAxisToWindow = false;
 
     Overlay* overlay;
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -3,6 +3,7 @@
 
 #include <QMainWindow>
 #include <QPixmap>
+#include "imagestructs.h"
 #include "imageselector.h"
 
 namespace Ui {
@@ -22,19 +23,21 @@ public:
     bool event(QEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
     ~MainWindow();
-    void setImage(const std::string& path, const ImageOptions_t &options);
+    void setImage(const ImageDetails_t &imageDetails);
     void setBlurRadius(unsigned int blurRadius);
     void setBackgroundOpacity(unsigned int opacity);
     void warn(std::string text);
     void setOverlay(Overlay* overlay);
     void setDebugMode(bool debugModeIn) {debugMode = debugModeIn;}
+    void setBaseOptions(const ImageDisplayOptions_t &baseOptionsIn) { baseImageOptions = baseOptionsIn; }
+    const ImageDisplayOptions_t &getBaseOptions() { return baseImageOptions; }
 private:
     Ui::MainWindow *ui;
 
-    std::string currentImage;
     unsigned int blurRadius = 20;
     unsigned int backgroundOpacity = 150;
-    ImageOptions_t imageOptions;
+    ImageDisplayOptions_t baseImageOptions;
+    ImageDetails_t currentImage;
     bool debugMode = false;
 
     Overlay* overlay;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -12,6 +12,7 @@ class MainWindow;
 class QLabel;
 class QKeyEvent;
 class Overlay;
+class ImageSwitcher;
 
 class MainWindow : public QMainWindow
 {
@@ -29,18 +30,24 @@ public:
     void warn(std::string text);
     void setOverlay(Overlay* overlay);
     void setDebugMode(bool debugModeIn) {debugMode = debugModeIn;}
-    void setBaseOptions(const ImageDisplayOptions_t &baseOptionsIn) { baseImageOptions = baseOptionsIn; }
+    void setBaseOptions(const ImageDisplayOptions_t &baseOptionsIn);
     const ImageDisplayOptions_t &getBaseOptions() { return baseImageOptions; }
+    void setImageSwitcher(ImageSwitcher *switcherIn) { switcher = switcherIn; }
+public slots:
+    void checkWindowSize();
 private:
     Ui::MainWindow *ui;
 
     unsigned int blurRadius = 20;
     unsigned int backgroundOpacity = 150;
     ImageDisplayOptions_t baseImageOptions;
+    bool imageAspectMatchesMonitor = false;
     ImageDetails_t currentImage;
     bool debugMode = false;
+    QSize lastScreenSize = {0,0};
 
-    Overlay* overlay;
+    Overlay* overlay = nullptr;
+    ImageSwitcher *switcher = nullptr;
 
     void drawText(QPixmap& image, int margin, int fontsize, QString text, int alignment);
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -24,15 +24,15 @@ public:
     bool event(QEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
     ~MainWindow();
-    void setImage(const ImageDetails_t &imageDetails);
+    void setImage(const ImageDetails &imageDetails);
     void setBlurRadius(unsigned int blurRadius);
     void setBackgroundOpacity(unsigned int opacity);
     void warn(std::string text);
     void setOverlay(Overlay* overlay);
-    void setDebugMode(bool debugModeIn) {debugMode = debugModeIn;}
-    void setBaseOptions(const ImageDisplayOptions_t &baseOptionsIn);
-    const ImageDisplayOptions_t &getBaseOptions() { return baseImageOptions; }
-    void setImageSwitcher(ImageSwitcher *switcherIn) { switcher = switcherIn; }
+    void setDebugMode(bool debugModeIn);
+    void setBaseOptions(const ImageDisplayOptions &baseOptionsIn);
+    const ImageDisplayOptions &getBaseOptions();
+    void setImageSwitcher(ImageSwitcher *switcherIn);
 public slots:
     void checkWindowSize();
 private:
@@ -40,9 +40,9 @@ private:
 
     unsigned int blurRadius = 20;
     unsigned int backgroundOpacity = 150;
-    ImageDisplayOptions_t baseImageOptions;
+    ImageDisplayOptions baseImageOptions;
     bool imageAspectMatchesMonitor = false;
-    ImageDetails_t currentImage;
+    ImageDetails currentImage;
     bool debugMode = false;
     QSize lastScreenSize = {0,0};
 

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -19,6 +19,11 @@ Overlay::Overlay(const std::string overlayInput):
 
 Overlay::~Overlay() {}
 
+void Overlay::setDebugMode(const bool debugModeIn) 
+{ 
+  debugMode = debugModeIn; 
+}
+
 void Overlay::parseInput() {
   QString str = QString(overlayInput.c_str());
   QStringList corners = str.split(QLatin1Char(';'));

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -27,7 +27,7 @@ class Overlay
     int getMarginBottomRight();
     int getFontsizeBottomRight();
 
-    void setDebugMode(const bool debugModeIn) { debugMode = debugModeIn; }
+    void setDebugMode(const bool debugModeIn);
 
   private:
     const std::string overlayInput;

--- a/src/pathtraverser.cpp
+++ b/src/pathtraverser.cpp
@@ -61,3 +61,24 @@ const std::string DefaultPathTraverser::getImagePath(const std::string image) co
 {
   return directory.filePath(QString(image.c_str())).toStdString();
 }
+
+
+ImageListPathTraverser::ImageListPathTraverser(const std::string &imageListString):
+  PathTraverser("")
+{
+  QString str = QString(imageListString.c_str());
+  imageList = str.split(QLatin1Char(','));
+}
+
+ImageListPathTraverser::~ImageListPathTraverser() {}
+
+
+QStringList ImageListPathTraverser::getImages() const
+{
+  return imageList;
+}
+
+const std::string ImageListPathTraverser::getImagePath(const std::string image) const
+{
+  return image;
+}

--- a/src/pathtraverser.cpp
+++ b/src/pathtraverser.cpp
@@ -25,7 +25,7 @@ QStringList PathTraverser::getImageFormats() const {
   return imageFormats;
 }
 
-void PathTraverser::LoadOptionsForDirectory(const std::string &directoryPath, ImageOptions_t &options) const
+void PathTraverser::LoadOptionsForDirectory(const std::string &directoryPath, ImageDisplayOptions_t &options) const
 {
   QDir directory(directoryPath.c_str());
   QString jsonFile = directory.filePath(QString("options.json"));
@@ -79,7 +79,7 @@ const std::string RecursivePathTraverser::getImagePath(const std::string image) 
   return image;
 }
 
-void RecursivePathTraverser::UpdateOptionsForImage(const std::string& filename, ImageOptions_t& options) const
+void RecursivePathTraverser::UpdateOptionsForImage(const std::string& filename, ImageDisplayOptions_t& options) const
 {
   QDir d = QFileInfo(filename.c_str()).absoluteDir();
   LoadOptionsForDirectory(d.absolutePath().toStdString(), options);
@@ -103,7 +103,7 @@ const std::string DefaultPathTraverser::getImagePath(const std::string image) co
   return directory.filePath(QString(image.c_str())).toStdString();
 }
 
-void DefaultPathTraverser::UpdateOptionsForImage(const std::string& filename, ImageOptions_t& options) const
+void DefaultPathTraverser::UpdateOptionsForImage(const std::string& filename, ImageDisplayOptions_t& options) const
 {
   UNUSED(filename);
   LoadOptionsForDirectory(directory.absolutePath().toStdString(), options);
@@ -129,7 +129,7 @@ const std::string ImageListPathTraverser::getImagePath(const std::string image) 
   return image;
 }
 
-void ImageListPathTraverser::UpdateOptionsForImage(const std::string& filename, ImageOptions_t& options) const
+void ImageListPathTraverser::UpdateOptionsForImage(const std::string& filename, ImageDisplayOptions_t& options) const
 {
   // no per file options modification supported
   UNUSED(filename);

--- a/src/pathtraverser.cpp
+++ b/src/pathtraverser.cpp
@@ -51,7 +51,6 @@ void PathTraverser::LoadOptionsForDirectory(const std::string &directoryPath, Im
         std::cout << "Fit Aspect:" << options.fitAspectAxisToWindow << std::endl;
       }
     }
-    // read json
   }
 }
 

--- a/src/pathtraverser.cpp
+++ b/src/pathtraverser.cpp
@@ -25,8 +25,9 @@ QStringList PathTraverser::getImageFormats() const {
   return imageFormats;
 }
 
-void PathTraverser::LoadOptionsForDirectory(const std::string &directoryPath, ImageDisplayOptions_t &options) const
+ImageDisplayOptions PathTraverser::LoadOptionsForDirectory(const std::string &directoryPath, const ImageDisplayOptions &baseOptions) const
 {
+  ImageDisplayOptions options = baseOptions;
   QDir directory(directoryPath.c_str());
   QString jsonFile = directory.filePath(QString("options.json"));
   if(directory.exists(jsonFile))
@@ -52,6 +53,7 @@ void PathTraverser::LoadOptionsForDirectory(const std::string &directoryPath, Im
       }
     }
   }
+  return options;
 }
 
 RecursivePathTraverser::RecursivePathTraverser(const std::string path,bool debugMode):
@@ -78,10 +80,10 @@ const std::string RecursivePathTraverser::getImagePath(const std::string image) 
   return image;
 }
 
-void RecursivePathTraverser::UpdateOptionsForImage(const std::string& filename, ImageDisplayOptions_t& options) const
+ImageDisplayOptions RecursivePathTraverser::UpdateOptionsForImage(const std::string& filename, const ImageDisplayOptions& baseOptions) const
 {
   QDir d = QFileInfo(filename.c_str()).absoluteDir();
-  LoadOptionsForDirectory(d.absolutePath().toStdString(), options);
+  return LoadOptionsForDirectory(d.absolutePath().toStdString(), baseOptions);
 }
 
 DefaultPathTraverser::DefaultPathTraverser(const std::string path,bool debugMode):
@@ -102,10 +104,10 @@ const std::string DefaultPathTraverser::getImagePath(const std::string image) co
   return directory.filePath(QString(image.c_str())).toStdString();
 }
 
-void DefaultPathTraverser::UpdateOptionsForImage(const std::string& filename, ImageDisplayOptions_t& options) const
+ImageDisplayOptions DefaultPathTraverser::UpdateOptionsForImage(const std::string& filename, const ImageDisplayOptions& baseOptions) const
 {
   UNUSED(filename);
-  LoadOptionsForDirectory(directory.absolutePath().toStdString(), options);
+  return LoadOptionsForDirectory(directory.absolutePath().toStdString(), baseOptions);
 }
 
 ImageListPathTraverser::ImageListPathTraverser(const std::string &imageListString,bool debugMode):
@@ -128,9 +130,10 @@ const std::string ImageListPathTraverser::getImagePath(const std::string image) 
   return image;
 }
 
-void ImageListPathTraverser::UpdateOptionsForImage(const std::string& filename, ImageDisplayOptions_t& options) const
+ImageDisplayOptions ImageListPathTraverser::UpdateOptionsForImage(const std::string& filename, const ImageDisplayOptions& baseOptions) const
 {
   // no per file options modification supported
   UNUSED(filename);
-  UNUSED(options);
+  UNUSED(baseOptions);
+  return ImageDisplayOptions();
 }

--- a/src/pathtraverser.h
+++ b/src/pathtraverser.h
@@ -16,13 +16,13 @@ class PathTraverser
     virtual ~PathTraverser();
     virtual QStringList getImages() const = 0;
     virtual const std::string getImagePath(const std::string image) const = 0;
-    virtual void UpdateOptionsForImage(const std::string& filename, ImageDisplayOptions_t& options) const = 0;
+    virtual ImageDisplayOptions UpdateOptionsForImage(const std::string& filename, const ImageDisplayOptions& baseOptions) const = 0;
 
   protected:
     const std::string path;
     bool debugMode = false;
     QStringList getImageFormats() const;
-    void LoadOptionsForDirectory(const std::string &directoryPath, ImageDisplayOptions_t &options) const;
+    ImageDisplayOptions LoadOptionsForDirectory(const std::string &directoryPath, const ImageDisplayOptions &baseOptions) const;
 };
 
 class RecursivePathTraverser : public PathTraverser
@@ -32,7 +32,7 @@ class RecursivePathTraverser : public PathTraverser
     virtual ~RecursivePathTraverser();
     QStringList getImages() const;
     virtual const std::string getImagePath(const std::string image) const;
-    virtual void UpdateOptionsForImage(const std::string& filename, ImageDisplayOptions_t& options) const;
+    virtual ImageDisplayOptions UpdateOptionsForImage(const std::string& filename, const ImageDisplayOptions& baseOptions) const;
 };
 
 class DefaultPathTraverser : public PathTraverser
@@ -42,7 +42,7 @@ class DefaultPathTraverser : public PathTraverser
     virtual ~DefaultPathTraverser();
     QStringList getImages() const;
     virtual const std::string getImagePath(const std::string image) const;
-    virtual void UpdateOptionsForImage(const std::string& filename, ImageDisplayOptions_t& options) const;
+    virtual ImageDisplayOptions UpdateOptionsForImage(const std::string& filename, const ImageDisplayOptions& baseOptions) const;
   private:
     QDir directory;
 };
@@ -54,7 +54,7 @@ class ImageListPathTraverser : public PathTraverser
     virtual ~ImageListPathTraverser();
     QStringList getImages() const;
     virtual const std::string getImagePath(const std::string image) const;
-    virtual void UpdateOptionsForImage(const std::string& filename, ImageDisplayOptions_t& options) const;
+    virtual ImageDisplayOptions UpdateOptionsForImage(const std::string& filename, const ImageDisplayOptions& options) const;
   private:
     QStringList imageList;
 };

--- a/src/pathtraverser.h
+++ b/src/pathtraverser.h
@@ -16,13 +16,13 @@ class PathTraverser
     virtual ~PathTraverser();
     virtual QStringList getImages() const = 0;
     virtual const std::string getImagePath(const std::string image) const = 0;
-    virtual void UpdateOptionsForImage(const std::string& filename, ImageOptions_t& options) const = 0;
+    virtual void UpdateOptionsForImage(const std::string& filename, ImageDisplayOptions_t& options) const = 0;
 
   protected:
     const std::string path;
     bool debugMode = false;
     QStringList getImageFormats() const;
-    void LoadOptionsForDirectory(const std::string &directoryPath, ImageOptions_t &options) const;
+    void LoadOptionsForDirectory(const std::string &directoryPath, ImageDisplayOptions_t &options) const;
 };
 
 class RecursivePathTraverser : public PathTraverser
@@ -32,7 +32,7 @@ class RecursivePathTraverser : public PathTraverser
     virtual ~RecursivePathTraverser();
     QStringList getImages() const;
     virtual const std::string getImagePath(const std::string image) const;
-    virtual void UpdateOptionsForImage(const std::string& filename, ImageOptions_t& options) const;
+    virtual void UpdateOptionsForImage(const std::string& filename, ImageDisplayOptions_t& options) const;
 };
 
 class DefaultPathTraverser : public PathTraverser
@@ -42,7 +42,7 @@ class DefaultPathTraverser : public PathTraverser
     virtual ~DefaultPathTraverser();
     QStringList getImages() const;
     virtual const std::string getImagePath(const std::string image) const;
-    virtual void UpdateOptionsForImage(const std::string& filename, ImageOptions_t& options) const;
+    virtual void UpdateOptionsForImage(const std::string& filename, ImageDisplayOptions_t& options) const;
   private:
     QDir directory;
 };
@@ -54,7 +54,7 @@ class ImageListPathTraverser : public PathTraverser
     virtual ~ImageListPathTraverser();
     QStringList getImages() const;
     virtual const std::string getImagePath(const std::string image) const;
-    virtual void UpdateOptionsForImage(const std::string& filename, ImageOptions_t& options) const;
+    virtual void UpdateOptionsForImage(const std::string& filename, ImageDisplayOptions_t& options) const;
   private:
     QStringList imageList;
 };

--- a/src/pathtraverser.h
+++ b/src/pathtraverser.h
@@ -41,4 +41,14 @@ class DefaultPathTraverser : public PathTraverser
     QDir directory;
 };
 
+class ImageListPathTraverser : public PathTraverser
+{
+  public:
+    ImageListPathTraverser(const std::string &imageListString);
+    virtual ~ImageListPathTraverser();
+    QStringList getImages() const;
+    virtual const std::string getImagePath(const std::string image) const;
+  private:
+    QStringList imageList;
+};
 #endif // PATHTRAVERSER_H

--- a/src/pathtraverser.h
+++ b/src/pathtraverser.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <QDir>
 #include <QStringList>
+#include "imageselector.h"
 
 static const QStringList supportedFormats={"jpg","jpeg","png","tif","tiff"};
 
@@ -11,32 +12,37 @@ class MainWindow;
 class PathTraverser
 {
   public:
-    PathTraverser(const std::string path);
+    PathTraverser(const std::string path, bool debugModeIn);
     virtual ~PathTraverser();
     virtual QStringList getImages() const = 0;
     virtual const std::string getImagePath(const std::string image) const = 0;
+    virtual void UpdateOptionsForImage(const std::string& filename, ImageOptions_t& options) const = 0;
 
   protected:
     const std::string path;
+    bool debugMode = false;
     QStringList getImageFormats() const;
+    void LoadOptionsForDirectory(const std::string &directoryPath, ImageOptions_t &options) const;
 };
 
 class RecursivePathTraverser : public PathTraverser
 {
   public:
-    RecursivePathTraverser(const std::string path);
+    RecursivePathTraverser(const std::string path, bool debugModeIn);
     virtual ~RecursivePathTraverser();
     QStringList getImages() const;
     virtual const std::string getImagePath(const std::string image) const;
+    virtual void UpdateOptionsForImage(const std::string& filename, ImageOptions_t& options) const;
 };
 
 class DefaultPathTraverser : public PathTraverser
 {
   public:
-    DefaultPathTraverser(const std::string path);
+    DefaultPathTraverser(const std::string path, bool debugModeIn);
     virtual ~DefaultPathTraverser();
     QStringList getImages() const;
     virtual const std::string getImagePath(const std::string image) const;
+    virtual void UpdateOptionsForImage(const std::string& filename, ImageOptions_t& options) const;
   private:
     QDir directory;
 };
@@ -44,10 +50,11 @@ class DefaultPathTraverser : public PathTraverser
 class ImageListPathTraverser : public PathTraverser
 {
   public:
-    ImageListPathTraverser(const std::string &imageListString);
+    ImageListPathTraverser(const std::string &imageListString, bool debugModeIn);
     virtual ~ImageListPathTraverser();
     QStringList getImages() const;
     virtual const std::string getImagePath(const std::string image) const;
+    virtual void UpdateOptionsForImage(const std::string& filename, ImageOptions_t& options) const;
   private:
     QStringList imageList;
 };


### PR DESCRIPTION
- Adding an optional "options.json" per image folder to control the display of images in that folder. Currently just setting the stretch options (via a "fitAspectAxisToWindow" ) key is supported.
- Added a monitor aspect ratio mode, to have the displayed images aspect match the current monitors aspect
- Changed from passing a simple std::string filename for the image to load to a ImageDetails_t structure that encapsulates state and display option data for the image
- Added code to clamp the display window size to the monitor resolution. I was noticing incorrect window sizes if the screen was rotated during the programs lifetime, this code makes sure to correct the size if needed. In particular running:
`DISPLAY=:0.0 xrandr --output HDMI-1 --rotate left`
`DISPLAY=:0.0 xrandr --output HDMI-1 --rotate normal`
`DISPLAY=:0.0 xrandr --output HDMI-1 --rotate left`
during a run would result in bad main window dimensions.