### PR TITLE
configurable transition time

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project is maintained by myself during my spare time. If you like and use i
 ## Usage
 
 ```
-slide [-t rotation_seconds] [-a aspect] [-o background_opacity(0..255)] [-b blur_radius] -p image_folder [-r] [-O overlay_string] [-v] [--verbose] [--stretch]
+slide [-t rotation_seconds] [-T transition_seconds] [-c/--overlay-color overlay_color(#rrggbb)] [-a aspect] [-o background_opacity(0..255)] [-b blur_radius] -p image_folder [-r] [-O overlay_string] [-v]  [-s] [-S] [--verbose] [--stretch]
 ```
 
 * `image_folder`: where to search for images (.jpg files)
@@ -25,6 +25,7 @@ slide [-t rotation_seconds] [-a aspect] [-o background_opacity(0..255)] [-b blur
 * `-s` for shuffle instead of random image rotation
 * `-S` for sorted rotation (files ordered by name, first images then subfolders)
 * `rotation_seconds(default=30)`: time until next random image is chosen from the given folder
+* `transition_seconds(default=1)`: time of image transition animation. Default is 1 second, and transition animation will be disabled if the value is set to 0
 * `aspect(default=a)`: the required aspect ratio of the picture to display. Valid values are 'a' (all), 'l' (landscape) and 'p' (portrait)
 * `background_opacity(default=150)`: opacity of the background filling image between 0 (black background) and 255
 * `blur_radius(default=20)`: blur radius of the background filling image
@@ -45,7 +46,7 @@ slide [-t rotation_seconds] [-a aspect] [-o background_opacity(0..255)] [-b blur
     * `<dir>`directory of the current image
     * `<path>`path to the current image without filename
   * Example: `slide -p ./images -O "20|60|Time: <time>;;;Picture taken at <exifdatetime>"`
-      
+* `-c` or `--overlay-color` the color of the overlay text, in the form of 3 or 6 digits hex rgb string prefixed by `#`, for example `#00FF00` or `#0F0` for color 🟢
 To exit the application, press escape. If you're using a touch display, touch all 4 corners at the same time.
 
 ## Dependencies

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,7 @@
 #include <memory>
 
 void usage(std::string programName) {
-    std::cerr << "Usage: " << programName << " [-t rotation_seconds] [-a aspect('l','p','a')] [-o background_opacity(0..255)] [-b blur_radius] -p image_folder [-r] [-s] [-v] [--verbose] [--stretch]" << std::endl;
+    std::cerr << "Usage: " << programName << " [-t rotation_seconds] [-T transition_seconds] [-c/--overlay-color #rrggbb] [-a aspect('l','p','a')] [-o background_opacity(0..255)] [-b blur_radius] -p image_folder [-r] [-O overlay_string] [-s] [-S] [-v] [--verbose] [--stretch]" << std::endl;
 }
 
 int main(int argc, char *argv[])
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
     {"overlay-color", required_argument, 0,           'c'},
   };
   int option_index = 0;
-  while ((opt = getopt_long(argc, argv, "b:p:t:o:O:c:a:rsSv", long_options, &option_index)) != -1) {
+  while ((opt = getopt_long(argc, argv, "b:p:t:T:o:O:c:a:rsSv", long_options, &option_index)) != -1) {
     switch (opt) {
       case 0:
           /* If this option set a flag, do nothing else now. */
@@ -69,6 +69,9 @@ int main(int argc, char *argv[])
         break;
       case 't':
         rotationSeconds = atoi(optarg);
+        break;
+      case 'T':
+	  w.setTransitionTime(atoi(optarg));
         break;
       case 'b':
         w.setBlurRadius(atoi(optarg));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -105,13 +105,14 @@ bool MainWindow::event(QEvent* event)
 void MainWindow::resizeEvent(QResizeEvent* event)
 {
    QMainWindow::resizeEvent(event);
-   updateImage(true);
+   this->findChild<QLabel*>("image")->clear();
+   updateImage();
 }
 
 void MainWindow::setImage(std::string path)
 {
     currentImage = path;
-    updateImage(false);
+    updateImage();
 }
 
 int MainWindow::getImageRotation()
@@ -149,14 +150,14 @@ int MainWindow::getImageRotation()
     return degrees;
 }
 
-void MainWindow::updateImage(bool immediately)
+void MainWindow::updateImage()
 {
     if (currentImage == "")
       return;
 
     QLabel *label = this->findChild<QLabel*>("image");
     const QPixmap* oldImage = label->pixmap();
-    if (oldImage != NULL && !immediately)
+    if (oldImage != NULL && transitionSeconds > 0)
     {
       QPalette palette;
       palette.setBrush(QPalette::Background, *oldImage);
@@ -199,13 +200,13 @@ void MainWindow::updateImage(bool immediately)
 
     label->setPixmap(background);
 
-    if (oldImage != NULL && !immediately)
+    if (oldImage != NULL && transitionSeconds > 0)
     {
       auto effect = new QGraphicsOpacityEffect(label);
       effect->setOpacity(0.0);
       label->setGraphicsEffect(effect);
       QPropertyAnimation* animation = new QPropertyAnimation(effect, "opacity");
-      animation->setDuration(1000);
+      animation->setDuration(transitionSeconds*1000);
       animation->setStartValue(0);
       animation->setEndValue(1);
       animation->start(QAbstractAnimation::DeleteWhenStopped);
@@ -340,6 +341,10 @@ void MainWindow::setBackgroundOpacity(unsigned int backgroundOpacity)
 void MainWindow::setOverlayHexRGB(QString overlayHexRGB)
 {
     this->overlayHexRGB = overlayHexRGB;
+
+void MainWindow::setTransitionTime(unsigned int transitionSeconds)
+{
+    this->transitionSeconds = transitionSeconds;
 }
 
 void MainWindow::warn(std::string text)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -24,6 +24,7 @@ public:
     void setImage(std::string path);
     void setBlurRadius(unsigned int blurRadius);
     void setBackgroundOpacity(unsigned int opacity);
+    void setTransitionTime(unsigned int transitionSeconds);
     void warn(std::string text);
     void setOverlay(Overlay* overlay);
     void setAspect(char aspectIn);
@@ -36,6 +37,7 @@ private:
     std::string currentImage;
     unsigned int blurRadius = 20;
     unsigned int backgroundOpacity = 150;
+    unsigned int transitionSeconds = 1;
     char aspect = 'a';
     bool debugMode = false;
     bool fitAspectAxisToWindow = false;
@@ -45,7 +47,7 @@ private:
 
     void drawText(QPixmap& image, int margin, int fontsize, QString text, int alignment);
 
-    void updateImage(bool immediately);
+    void updateImage();
     int getImageRotation();
 
     QPixmap getBlurredBackground(const QPixmap& originalSize, const QPixmap& scaled);


### PR DESCRIPTION
__WHY__: make the transition animation duration configurable.


__WHAT__:
* make transition time configurable
  * added `-T` option for configuring the duration of the transition animation.
  * default to 1 second, use `-T 0` to disable transition animation.
* fix artifact caused by resizing event

__NOTE__: C++ is not my expertise, and I'm not quite sure if the added `this->findChild<QLabel*>("image")->clear();` in resize event handler will cause any side effects.