### PR TITLE
skip overlay processing when no overlay is specified

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,9 +138,14 @@ int main(int argc, char *argv[])
     std::cout << "Rotation Time: " << rotationSeconds << std::endl;
     std::cout << "Overlay input: " << overlay << std::endl;
   }
+
   Overlay o(overlay);
   o.setDebugMode(debugMode);
-  w.setOverlay(&o);
+  if (!overlay.empty())
+  {
+    w.setOverlay(&o);
+  }
+
   w.setAspect(aspect);
   w.setDebugMode(debugMode);
   w.setFitAspectAxisToWindow(fitAspectAxisToWindow);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -39,7 +39,7 @@ private:
     bool debugMode = false;
     bool fitAspectAxisToWindow = false;
 
-    Overlay* overlay;
+    Overlay* overlay = NULL;
 
     void drawText(QPixmap& image, int margin, int fontsize, QString text, int alignment);
 


### PR DESCRIPTION
__WHY__: image preprocessing is so slow on my device and is causing image rotation time to be unpredictable and sometimes transition animation to get cut off.
Some naïve profiling showed that the processing of overlay takes about 1.5 seconds on my device, even with no overlay text set with the calling args.

__WHAT__: This change is to not construct the overlay object if it is not provided from the calling command-line argument so that the overlay processing will be properly skipped.

__NOTE__: 3 jobs are done prior to updating the display with a new image:
* [image loading](https://github.com/NautiluX/slide/blob/master/src/mainwindow.cpp#L157),
* [image processing](https://github.com/NautiluX/slide/blob/master/src/mainwindow.cpp#L172-L175), and 
* [overlay processing](https://github.com/NautiluX/slide/blob/master/src/mainwindow.cpp#L177-L198)

And the attempt in PR https://github.com/NautiluX/slide/pull/44 is to alleviate the long image loading time by offloading the work to a separate thread. 