### PR TITLE
configurable overlay color

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "pathtraverser.h"
 #include "overlay.h"
 #include <QApplication>
+#include <QRegularExpression>
 #include <iostream>
 #include <sys/file.h>
 #include <errno.h>
@@ -35,15 +36,18 @@ int main(int argc, char *argv[])
   bool fitAspectAxisToWindow = false;
   std::string valid_aspects = "alp"; // all, landscape, portait
   std::string overlay = "";
+  QString overlayHexRGB = QString();
+  QRegularExpression hexRGBMatcher("^#([0-9A-Fa-f]{3}){1,2}$");
   int debugInt = 0;
   int stretchInt = 0;
   static struct option long_options[] =
   {
-    {"verbose", no_argument,       &debugInt, 1},
-    {"stretch", no_argument,       &stretchInt, 1},
+    {"verbose",       no_argument,       &debugInt,   1},
+    {"stretch",       no_argument,       &stretchInt, 1},
+    {"overlay-color", required_argument, 0,           'c'},
   };
   int option_index = 0;
-  while ((opt = getopt_long(argc, argv, "b:p:t:o:O:a:rsSv", long_options, &option_index)) != -1) {
+  while ((opt = getopt_long(argc, argv, "b:p:t:o:O:c:a:rsSv", long_options, &option_index)) != -1) {
     switch (opt) {
       case 0:
           /* If this option set a flag, do nothing else now. */
@@ -85,6 +89,9 @@ int main(int argc, char *argv[])
       case 'O':
         overlay = optarg;
         break;
+      case 'c':
+        overlayHexRGB = QString::fromStdString(optarg);
+        break;
       case 'v':
         debugMode = true;
         break;
@@ -107,6 +114,16 @@ int main(int argc, char *argv[])
     std::cout << "Error: Path expected." << std::endl;
     usage(argv[0]);
     return 1;
+  }
+
+  if (!overlayHexRGB.isEmpty())
+  {
+    if(!hexRGBMatcher.match(overlayHexRGB).hasMatch())
+    {
+      std::cout << "Error: hex rgb string expected. e.g. #FFFFFF or #FFF" << std::endl;
+      return 1;
+    }
+    w.setOverlayHexRGB(overlayHexRGB);
   }
 
   std::unique_ptr<PathTraverser> pathTraverser;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -217,7 +217,7 @@ void MainWindow::updateImage(bool immediately)
 void MainWindow::drawText(QPixmap& image, int margin, int fontsize, QString text, int alignment) {
   //std::cout << "text: " << text.toStdString()  << " margin: " << margin << " fontsize: " << fontsize<< std::endl;
   QPainter pt(&image);
-  pt.setPen(QPen(Qt::white));
+  pt.setPen(QPen(QColor(overlayHexRGB)));
   pt.setFont(QFont("Sans", fontsize, QFont::Bold));
   QRect marginRect = image.rect().adjusted(
       margin,
@@ -335,6 +335,11 @@ void MainWindow::setBlurRadius(unsigned int blurRadius)
 void MainWindow::setBackgroundOpacity(unsigned int backgroundOpacity)
 {
     this->backgroundOpacity = backgroundOpacity;
+}
+
+void MainWindow::setOverlayHexRGB(QString overlayHexRGB)
+{
+    this->overlayHexRGB = overlayHexRGB;
 }
 
 void MainWindow::warn(std::string text)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -29,6 +29,7 @@ public:
     void setAspect(char aspectIn);
     void setDebugMode(bool debugModeIn) {debugMode = debugModeIn;}
     void setFitAspectAxisToWindow(bool fitAspectAxisToWindowIn) { fitAspectAxisToWindow = fitAspectAxisToWindowIn; }
+    void setOverlayHexRGB(QString overlayHexRGB);
 private:
     Ui::MainWindow *ui;
 
@@ -38,6 +39,7 @@ private:
     char aspect = 'a';
     bool debugMode = false;
     bool fitAspectAxisToWindow = false;
+    QString overlayHexRGB;
 
     Overlay* overlay;
 


### PR DESCRIPTION
__WHY__: many of the times the hardcoded white color either makes the overlay harsh to the eye when it can be seen or makes the overlay hard to see when the background of the picture is bright.

__WHAT__: add a configuration option `-c` or `--overlay-color`, which takes a hex RGB color code as the argument, to customize the color of the overlay.

__NOTE__: I can see this could also be approached from a per corner implementation, by modifying the `Overlay` class (which probably would be better since config string provides more flexibility), feel free to reject if you think this does not fit into the project.